### PR TITLE
Bump patsy to 1.0.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.0.0" %}
+{% set version = "1.0.1" %}
 
 {% set python_min = python_min | default("3.9") %}
 
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/p/patsy/patsy-{{ version }}.tar.gz
-  sha256: 787d2a5d15333fb1e4dc11331b2e7fd17d92f9a815db2fbca29b50c0e6c0159d
+  sha256: e786a9391eec818c054e359b737bbce692f051aee4c661f4141cc88fb459c0c4
 
 build:
   noarch: python


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

@bollwyvl Can you please merge this one in relatively quickly? The version of patsy I released yesterday inadvertently had a hard dependency on `pytest`, which breaks all patsy installations. I have separately requested that the 1.0.0 release be marked as broken in conda-forge.
